### PR TITLE
feat: Feat/only infoview for lean

### DIFF
--- a/src/main/kotlin/lean4ij/infoview/InfoviewLibrarySearchHelper.kt
+++ b/src/main/kotlin/lean4ij/infoview/InfoviewLibrarySearchHelper.kt
@@ -1,0 +1,12 @@
+package lean4ij.infoview
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ext.LibrarySearchHelper
+import lean4ij.project.LeanProjectService
+
+class InfoviewLibrarySearchHelper : LibrarySearchHelper {
+    override fun isLibraryExists(project: Project): Boolean {
+        return project.service<LeanProjectService>().isLeanProject()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,11 @@
 
     <resource-bundle>messages.MyBundle</resource-bundle>
 
+    <!-- check the document: -->
+    <!-- https://plugins.jetbrains.com/docs/intellij/plugin-extensions.html#declaring-extensions -->
+    <!-- and -->
+    <!-- https://plugins.jetbrains.com/docs/intellij/intellij-platform-extension-point-list.html -->
+    <!-- for knowledge about extensions -->
     <extensions defaultExtensionNs="com.intellij">
         <defaultLiveTemplates file="/liveTemplates/Lean4.xml"/>
         <liveTemplateContext
@@ -61,13 +66,15 @@
         <annotator language="lean4" implementationClass="lean4ij.language.Lean4Annotator"/>
 
         <!-- check https://plugins.jetbrains.com/docs/intellij/icons.html#mapping-entries for making icons to respect theme -->
-        <toolWindow factoryClass="lean4ij.infoview.LeanInfoViewWindowFactory"
+        <library.toolWindow factoryClass="lean4ij.infoview.InfoViewWindowFactory"
                     id="LeanInfoViewWindow"
                     icon="/icons/infoview_icon.svg"
+                    librarySearchClass="lean4ij.infoview.InfoviewLibrarySearchHelper"
         />
-        <toolWindow factoryClass="lean4ij.infoview.external.JcefInfoviewTooWindowFactory"
+        <library.toolWindow factoryClass="lean4ij.infoview.external.JcefInfoviewTooWindowFactory"
                     id="LeanInfoviewJcef"
                     icon="/icons/jcef_icon.svg"
+                    librarySearchClass="lean4ij.infoview.InfoviewLibrarySearchHelper"
         />
 
         <postStartupActivity implementation="lean4ij.project.LeanProjectActivity"/>


### PR DESCRIPTION
Solve https://github.com/onriv/lean4ij/issues/103

This PR adds a logic to avoid showing infoview tool window in non-lean project
The extension point `com.intellij.librry.toolWindow` is hinted in the slack channel by Yuriy Artamonov
But I found no plugin using this. And searching for `com.intellij.library.toolWindow` in the source code of intellij-community
I find the maybe correct way for using this extension point. Comparing it with `com.intellij.toolWindow`,
the extra attribute is `librarySearchClass` with type `com.intellij.openapi.wm.ext.LibrarySearchHelper`
