### PR TITLE
Fix completions deleting everything before the caret

### DIFF
--- a/src/main/kotlin/lean4ij/lsp/Lean4LSPClientFeatures.kt
+++ b/src/main/kotlin/lean4ij/lsp/Lean4LSPClientFeatures.kt
@@ -9,6 +9,7 @@ import com.redhat.devtools.lsp4ij.client.features.LSPDiagnosticFeature
 import com.redhat.devtools.lsp4ij.client.features.LSPWorkspaceSymbolFeature
 import lean4ij.project.LeanProjectService
 import lean4ij.setting.Lean4Settings
+import org.eclipse.lsp4j.InitializeParams
 
 /**
  * per project with the getProject method in the base class
@@ -40,5 +41,14 @@ class Lean4LSPClientFeatures : LSPClientFeatures() {
         val selectedFile = FileEditorManager.getInstance(project)
             .selectedTextEditor?.virtualFile
         return selectedFile == file
+    }
+
+    override fun initializeParams(initializeParams: InitializeParams) {
+        // Setting this to true should make the LSP start filling out textEdit for completion items
+        // However, this currently doesn't seem to work, but it should probably stay here anyway
+        // See the test runner for Lean's LSP, which also explicitly sets this to true
+        // https://github.com/leanprover/lean4/blob/64219ac91e2930d3950637317c7dc4f7b45568d1/src/Lean/Server/Test/Runner.lean#L94
+        initializeParams.capabilities.textDocument.completion.completionItem.insertReplaceSupport = true
+        super.initializeParams(initializeParams)
     }
 }

--- a/src/main/kotlin/lean4ij/lsp/LeanLSPCompletionFeature.kt
+++ b/src/main/kotlin/lean4ij/lsp/LeanLSPCompletionFeature.kt
@@ -1,9 +1,14 @@
 package lean4ij.lsp
 
+import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.components.service
 import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
 import com.redhat.devtools.lsp4ij.client.features.LSPCompletionFeature
 import lean4ij.setting.Lean4Settings
+import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 /**
  * Add an impl for disable lsp completion for lean
@@ -14,5 +19,58 @@ class LeanLSPCompletionFeature : LSPCompletionFeature() {
 
     override fun isEnabled(file: PsiFile): Boolean {
         return lean4Settings.enableLspCompletion
+    }
+
+    override fun createLookupElement(
+        item: CompletionItem,
+        context: LSPCompletionContext
+    ): LookupElement? {
+
+        // This all fixes a bug, where accepting a completion suggestion erases everything before the cursor
+        //
+        // The LSP does not fill out the textEdit field properly (despite receiving insertReplaceSupport during init).
+        // This makes LSP4IJ try to find the current semantic token under the caret, using its text range
+        // to insert the completion into.
+        // However, whenever a letter is typed, the whole semantic token map is invalidated and cleared out.
+        // The map doesn't get repopulated until the completion popup is closed, and the token text range retrieval
+        // method instead returns a range referring to the whole file.
+        // The start of this range (0) ends up as the prefix offset for the completion, so applying the completion
+        // inserts it starting from offset 0 (i.e. the start of the file), erasing everything before the caret.
+        //
+        // When we don't get a TextEdit from the LSP, we can create our own using the IDE's PSI elements.
+        // This tells LSP4IJ that we're _certain_ about what we want to replace, bypassing the bug in the logic
+        // where it would try to figure this out based on the position of the caret.
+
+        if (item.textEdit == null) {
+            // The PSI element comes from the "completion file", and has a dummy suffix appended to it.
+            // Its reported length is about 19 characters longer, so the TextEdit end position is set
+            // until the current cursor position.
+            // When working with PSI elements, it's better to use the provided methods
+            // (in this case, replacing the element with a new one would be better).
+            // This is simply bolted onto the existing logic, but could be reworked by handling
+            // the replacement part later on too.
+
+            // Note that .originalElement exists, but leads to the exact same issue as described above.
+            // Attempting to refer to it under certain circumstances fails to find the original element,
+            // instead referring to the whole file, and so the whole text range of the file.
+            val psiElement = context.parameters.position
+            val elementStart = psiElement.startOffset
+            // Cursor offset rather than the PSI element end pos
+            val elementEnd = context.parameters.offset
+
+            // Char offset -> (line:char)
+            val lineNum = psiElement.containingFile.fileDocument.getLineNumber(elementStart)
+            val lineOffset = psiElement.containingFile.fileDocument.getLineStartOffset(lineNum)
+
+            val startPos = org.eclipse.lsp4j.Position(lineNum, elementStart - lineOffset)
+            val endPos = org.eclipse.lsp4j.Position(lineNum, elementEnd - lineOffset)
+
+            val textEdit = TextEdit(
+                org.eclipse.lsp4j.Range(startPos, endPos),
+                item.label
+            )
+            item.textEdit = Either.forLeft(textEdit)
+        }
+        return super.createLookupElement(item, context)
     }
 }


### PR DESCRIPTION
Fixes #164

I managed to figure out a way to work around some (probably) faulty logic within LSP4IJ - it causes problems for this plugin, at least. The CompletionFeature now injects its own TextEdit definition into the item if it isn't provided by the LSP (which it isn't at the moment). I'm unsure if this is a LSP4IJ bug, a consequence of some weird interaction between the two plugins, or something else entirely.

At the moment, the fixed implementation replaces from the start of the token until the caret. Ideally, it would be able to replace the whole token (even if the caret is in the middle), but this is good enough for common code completion, at least.

The implementation is a little hacky, but it's a fairly minimal change & works well enough. Again, ideally, the plugin would handle replacing PSI elements using the intended, provided methods (e.g. `.replace(newElement)`), but that would require more work.

More details directly in code comments.

I'll continue testing the plugin with this patch to make sure it doesn't break something really badly. I'm a long-time JetBrains user, but I've never done any work on plugin code or involving LSPs, though I think that the fix should work well enough.